### PR TITLE
DecisionTree's visualisation in print_visualTree()

### DIFF
--- a/build/lib/p_decision_tree/DecisionTree.py
+++ b/build/lib/p_decision_tree/DecisionTree.py
@@ -258,3 +258,102 @@ class DecisionTree(object):
             except:
                 print("You either have not installed the 'dot' to visualize the decision tree or the reulted .pdf file is open!")
         return dot
+    
+##########################################################################################################
+    
+#from p_decision_tree.DecisionTree import DecisionTree
+
+## Prepare the descriptive and target features -
+## Obtaining lists with the names of the features is straightforward.
+## For the values - we cast the column values to 'str' and extract them 
+
+#ua_descriptive_features = ['SCHEDULED_DEPARTURE_CATEGORY', 'DISTANCE_CATEGORY', 'DAY_OF_WEEK']
+#ua_descriptive_values = ua_flights[ua_descriptive_features].astype(str).values
+#ua_target_values = ua_flights['DELAY'].astype(str).values
+
+## Train an entropy-based Decision Tree for classifying delays
+#ua_decision_tree_entropy = DecisionTree(sample=ua_descriptive_values,
+#                                        attributes=ua_descriptive_features,
+#                                        labels=ua_target_values,
+#                                        criterion="entropy")
+
+## Apply ID3 algorithm
+#ua_decision_tree_entropy.id3(gain_threshold=0, minimum_samples=1000)
+
+## Proceed to generate visual output with graphiz
+## The resulting pdf file is submitted alongside the notebook.
+#ua_decision_tree_entropy.print_visualTree(render=True)
+
+## Print the total entropy of the used dataset
+#print("Entropy-based Decision Tree: Entropy = %.5f" % ua_decision_tree_entropy.entropy)
+
+##########################################################################################################
+
+## shouldDraw() accepts a node and checks whether all children
+## of its children nodes are identical. A set of those children 
+## is then returned, allowing us to decide whether we should or
+## should not draw the node in question.
+
+## EXAMPLE - we SHOULD NOT draw the node 'DAY_OF_WEEK' when its parent is 'Night'.
+## The reason is that, for every day of the week, the outcome is the same ('Acceptable_delay').
+## For that reason, for each of the children (in this case - the days of the week) we check
+## whether they themselves have children (then they are not parents of leaves) or if they do not
+## (then they are parents of leaves). If they are parents of leaves, we can check whether the
+## leaves are identical, and omit drawing unnecessary nodes.
+ 
+def shouldDraw(node):
+    # print(node.value)
+    leaves = []
+    if (node.childs):
+        for child in node.childs:
+            if (not(child.next.childs)):
+                leaves.append(child.next.value)
+    return set(leaves)
+
+## printTree() is very much alike to print_visualTree(self, render=True) from the DecisionTree.py file:
+## https://github.com/m4jidRafiei/Decision-Tree-Python-/blob/master/build/lib/p_decision_tree/DecisionTree.py
+## CHANGES: 
+##     - changed the name of deque() to 'nodes'
+##     - after [if(child.next.childs)] (line 240 in original code) - added additional checks
+
+def printTree(root, render=True):
+    dot = Digraph(comment='Decision Tree')
+    if root:
+        root.name = "root"
+        nodes = deque()
+        nodes.append(root)
+        while len(nodes) > 0:
+            root = nodes.popleft()
+            dot.node(root.name, root.value)
+            if root.childs:
+                for child in root.childs:
+                    child.name = str(random())
+                    dot.node(child.name, child.value)
+                    dot.edge(root.name,child.name)
+                    if(child.next.childs):
+                        chld = child.next
+                        decision_set = shouldDraw(chld)
+                        # print(decision_set)
+                        ## If all leaves are identical, skip creating nodes 
+                        if (len(decision_set) == 1):
+                            name = str(random())
+                            dot.node(name, list(decision_set)[0])
+                            dot.edge(child.name, name)
+                        ## Otherwise, create the parent node and prepare children 
+                        ## for further visualisation by enque()-ing them
+                        else:        
+                            child.next.name = str(random())
+                            dot.node(child.next.name, child.next.value)
+                            dot.edge(child.name,child.next.name)
+            elif root.next:
+                dot.node(root.next, root.next)
+                dot.edge(root.value,root.next)
+    if render:
+        try:
+            dot.render('output/visualTree.gv', view=True)
+        except:
+            print("You either have not installed the 'dot' to visualize the decision tree or the reulted .pdf file is open!")
+    return dot
+
+## Concrete example, based on the created decision tree
+printTree(ua_decision_tree_entropy.root, render=True)


### PR DESCRIPTION
Hey,

A you may know, the code from DecisionTree.py (or the p_decision_tree library, in general) is currently being used in the Introduction to Data Science course in order to illustrate the concepts of decision trees with categorical features. I am a student (Master in Data Science) taking the course and have spend some time exploring the code. In this pull request I propose a change to the visualisation part (from line 222 in the original code, kept unchanged).

The idea is to skip drawing nodes for which the children only have a single child (so skip drawing the parent of leaves and the parent of these parents of leaves) IF all of the leaf nodes share the same value. We aim to achieve that by the shouldDraw()-function which provides a criterion for that. We can then use it to test whether a node is a parent of nodes linked to leaves which are all identical (and consequently draw only the leaf-label). For further details, please look at the example and comments provided.

For further details and discussions you can contact me at: atanas.gruev.98@gmail.com.
From the e-mail address above I send as attachments two pdf-files. The initial one using the code provided to generate a decision tree. The second has the suggested changes, and displays a somewhat-pruned tree which is more straightforward and takes up less space.

Cheers,
Atanas Gruev